### PR TITLE
New random module to wrap stream module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*egg-info
+build
+*.npz
+*.pyc

--- a/README.md
+++ b/README.md
@@ -7,23 +7,29 @@ Math utilities (e.g. FFT, random number generation, convolutions) used for extra
 3. pip install .
 
 ## Running
-Currently runs on perlmutter in the [xgsmenv](https://github.com/exgalsky/xgsmenv) enviroment.
+Currently runs on perlmutter in the [xgsmenv](https://github.com/exgalsky/xgsmenv) environment.
 
-Example included here in [scripts/example.py](https://github.com/exgalsky/xgmutil/blob/master/scripts/example.py) will produce 20 random numbers from a normal distribution.
+Example included here in [scripts/example.py](https://github.com/exgalsky/xgmutil/blob/master/scripts/example.py) will produce 2 realizations of 20 random numbers each from a normal distribution stream.
 
 ```
-import xgmutil as mu
+import xgmutil as mu 
+import jax.numpy as jnp
 
-# create stream
-stream = mu.Stream(
-    seed = 13579,
-    nsub = 2
-)
+RNG_manager = mu.RNG_manager()
+print(f'master seed      : {RNG_manager.seed}')
+print(f'master key       : {RNG_manager.master_key}')
+example_rand_stream = RNG_manager.setup_stream('example', component_type='example type', dtype=jnp.float32, nsub=1024, force_no_gpu=False)
+print(f'component name   : {example_rand_stream.component}')
+print(f'component id     : {example_rand_stream.component_id}')
+print(f'component key    : {example_rand_stream.component_key}')
 
-seq = stream.generate(start=5,size=20)
 
-print('seq',seq)
-print('seq shape:',seq.shape)
-print('seq mean:',seq.mean())
+realization = 5
+rand_sample = example_rand_stream.generate(start=5,size=20, dist='normal', mc=realization)
+print(f'Realization no {realization}:',rand_sample)
+
+realization = 6
+rand_sample = example_rand_stream.generate(start=5,size=20, dist='normal', mc=realization)
+print(f'Realization no {realization}:',rand_sample)
 
 ```

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -1,13 +1,19 @@
-import scaleran as sr
+import xgmutil as mu 
+import jax.numpy as jnp
 
-# create stream
-stream = sr.Stream(
-    seed = 13579,
-    nsub = 2
-)
+RNG_manager = mu.RNG_manager(seed = 13579)
+print(f'master seed      : {RNG_manager.seed}')
+print(f'master key       : {RNG_manager.master_key}')
+example_rand_stream = RNG_manager.setup_stream('example', component_type='example type', dtype=jnp.float32, nsub=1024, force_no_gpu=False)
+print(f'component name   : {example_rand_stream.component}')
+print(f'component id     : {example_rand_stream.component_id}')
+print(f'component key    : {example_rand_stream.component_key}')
 
-seq = stream.generate(start=5,size=20)
 
-print('seq',seq)
-print('seq shape:',seq.shape)
-print('seq mean:',seq.mean())
+realization = 5
+rand_sample = example_rand_stream.generate(start=5,size=20, dist='normal', mc=realization)
+print(f'Realization no {realization}:',rand_sample)
+
+realization = 6
+rand_sample = example_rand_stream.generate(start=5,size=20, dist='normal', mc=realization)
+print(f'Realization no {realization}:',rand_sample)

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -1,5 +1,24 @@
 import xgmutil as mu 
 import jax.numpy as jnp
+import jax
+
+cuda_build = False
+
+# Do jax.distributed.initialize if jaxlib is built with cuda
+if cuda_build:
+    jax.distributed.initialize()
+
+# create stream
+stream = mu.Stream(
+    seedkey = 13579,
+    nsub    = 2
+)
+
+seq = stream.generate(start=5,size=20)
+
+print('seq',seq)
+print('seq shape:',seq.shape)
+print('seq mean:',seq.mean())
 
 RNG_manager = mu.RNG_manager(seed = 13579)
 print(f'master seed      : {RNG_manager.seed}')

--- a/scripts/reproducibity-test.py
+++ b/scripts/reproducibity-test.py
@@ -1,20 +1,19 @@
 import xgmutil as mu
 import jax.numpy as jnp
 
-machine_name="MacbookPro2021_M1Max"
+machine_name="ThinkpadX1Carbon_Intel-i7-1270P"
 RNG_mgr = mu.RNG_manager()
-ran_stream = RNG_mgr.setup_stream('test')
+ran_stream = RNG_mgr.setup_stream('test', nsub=32**3)
 
 print("Using device:", ran_stream.device)
 
 dtypes = [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
 
 nsamples = 10
-output_file = f'./reproducibity_test_results-{ran_stream.component_id}_{machine_name}-{ran_stream.device}.npy'
+output_file = f'./reproducibity_test_results-{ran_stream.component_id}_{machine_name}-{ran_stream.device}.npz'
 
-with open(output_file, 'wb') as f:
-    for dtyp in dtypes:
-        sample = ran_stream.generate(mc=0, start=0, size=nsamples, dtype=dtyp, dist='normal')
-    jnp.save(output_file, sample)
-
-f.close()
+sample = []
+for dtyp in dtypes:
+    sample.append(ran_stream.generate(mc=0, start=0, size=nsamples, dtype=dtyp, dist='normal'))
+    print(sample[-1])
+jnp.savez(output_file, f32=sample[0], f64=sample[1], c64=sample[2], c128=sample[3])

--- a/scripts/reproducibity-test.py
+++ b/scripts/reproducibity-test.py
@@ -1,0 +1,20 @@
+import xgmutil as mu
+import jax.numpy as jnp
+
+machine_name="MacbookPro2021_M1Max"
+RNG_mgr = mu.RNG_manager()
+ran_stream = RNG_mgr.setup_stream('test')
+
+print("Using device:", ran_stream.device)
+
+dtypes = [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
+
+nsamples = 10
+output_file = f'./reproducibity_test_results-{ran_stream.component_id}_{machine_name}-{ran_stream.device}.npy'
+
+with open(output_file, 'wb') as f:
+    for dtyp in dtypes:
+        sample = ran_stream.generate(mc=0, start=0, size=nsamples, dtype=dtyp, dist='normal')
+    jnp.save(output_file, sample)
+
+f.close()

--- a/scripts/reproducibity-test.py
+++ b/scripts/reproducibity-test.py
@@ -1,19 +1,19 @@
 import xgmutil as mu
 import jax.numpy as jnp
 
-machine_name="ThinkpadX1Carbon_Intel-i7-1270P"
+machine_name="MacbookPro14_M1Max"
 RNG_mgr = mu.RNG_manager()
-ran_stream = RNG_mgr.setup_stream('test', nsub=32**3)
-
-print("Using device:", ran_stream.device)
 
 dtypes = [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
 
 nsamples = 10
-output_file = f'./reproducibity_test_results-{ran_stream.component_id}_{machine_name}-{ran_stream.device}.npz'
 
 sample = []
 for dtyp in dtypes:
-    sample.append(ran_stream.generate(mc=0, start=0, size=nsamples, dtype=dtyp, dist='normal'))
+    ran_stream = RNG_mgr.setup_stream('test', nsub=32**3, dtype=dtyp)
+    print("Using device:", ran_stream.device)
+    sample.append(ran_stream.generate(mc=0, start=0, size=nsamples, dist='normal'))
     print(sample[-1])
+
+output_file = f'./reproducibity_test_results-{ran_stream.component_id}_{machine_name}-{ran_stream.device}.npz'
 jnp.savez(output_file, f32=sample[0], f64=sample[1], c64=sample[2], c128=sample[3])

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup
 pname='xgmutil'
 setup(name=pname,
-      version='0.1',
-      description='Scalable random number generator using Jax',
+      version='0.2',
+      description='Math utilities for exgal sky simulation tools',
       url='http://github.com/exgalsky/xgmutil',
       author='exgalsky collaboration',
       license_files = ('LICENSE',),

--- a/xgmutil/__init__.py
+++ b/xgmutil/__init__.py
@@ -1,2 +1,3 @@
-from . import stream
+from . import stream, random
 from .stream import Stream
+from .random import RNG_manager, RNG_component

--- a/xgmutil/random.py
+++ b/xgmutil/random.py
@@ -1,0 +1,51 @@
+import jax.numpy as jnp 
+import jax.random as rdm 
+
+import xgmutil.stream as stream
+
+cmb_dict = {'cmb_tlm': 0, 'cmb_elm': 1, 'cmb_blm': 2}
+lens_dict = {'phi_lm': 3}
+# dust_list = [[4, 'dust_tlm'], [5, 'dust_elm'], [6, 'dust_blm']]
+# sync_list = [[7, 'sync_tlm'], [8, 'sync_elm'], [9, 'sync_blm']]
+ic_dict = {'ic_grid': 32}
+
+predefined_components = cmb_dict | lens_dict | ic_dict
+
+class RNG_component:
+    def __init__(self, component_name, stream_id, stream_key, **kwargs):
+        self.component     = component_name
+        self.component_id  = stream_id
+        self.component_key = stream_key
+        self.force_no_gpu  = kwargs.get('force_no_gpu',False)
+        self.nsub          = kwargs.get('nsub',1024**3)
+
+        self.stream = stream.Stream(force_no_gpu=self.force_no_gpu, seedkey=self.component_key, nsub=self.nsub)
+
+    def generate(self, **kwargs):
+        return self.stream.generate(**kwargs)
+
+class RNG_manager:
+    def __init__(self, seed = 57885161, n_components = 512):
+    # Mersenne exponents no 48. Ref: https://oeis.org/A000043 used as seed
+    # Do we hard code this here, or have it defined elsewhere and read here?
+
+        self.master_key  = rdm.PRNGKey(seed)
+        self.key_list    = rdm.split(self.master_key, num=n_components)
+        self.stream_no   = jnp.arange(0, n_components, dtype=jnp.int16)
+        self.stream_id   = [f"{seed}-{seq_no:{0}>3}" for seq_no in self.stream_no]
+        self.registry    = [None for _ in self.stream_no]
+
+        for key in predefined_components:
+            self.registry[predefined_components[key]] = key  
+
+    def _register_component(self, component_name, component_type):
+        unassigned_idx = [i for i, val in enumerate(self.registry) if val == None]
+        unassigned_stream = self.stream_no[unassigned_idx]
+        self.registry[jnp.min(unassigned_stream[unassigned_stream >= 128])] = component_name.lower()
+
+    def setup_stream(self, component_name, **kwargs):
+        if component_name in self.registry:
+            stream_no = self.registry.index(component_name)
+            return RNG_component(component_name, self.stream_id[stream_no], self.key_list[stream_no], **kwargs)
+    
+

--- a/xgmutil/random.py
+++ b/xgmutil/random.py
@@ -33,6 +33,9 @@ class RNG_component:
         self.stream = stream.Stream(force_no_gpu=_force_no_gpu, seedkey=self.component_key, nsub=self.nsub, dtype=self._dtype_stream)
 
     def generate(self, **kwargs):
+        mc  = kwargs.get('mc', 0)
+        self.stream.set_seedkey(mc)
+
         if self.dtype != self._dtype_stream: return (self.stream.generate(**kwargs)).astype(self.dtype)
         return self.stream.generate(**kwargs)
 

--- a/xgmutil/random.py
+++ b/xgmutil/random.py
@@ -37,14 +37,16 @@ class RNG_component:
         return self.stream.generate(**kwargs)
 
 class RNG_manager:
-    def __init__(self, seed = 57885161, n_components = 512):
+    def __init__(self, seed = 57885161):
     # Mersenne exponents no 48. Ref: https://oeis.org/A000043 used as seed
     # Do we hard code this here, or have it defined elsewhere and read here?
+        self.seed = seed
+        self.n_components = 512
 
-        self.master_key  = rdm.PRNGKey(seed)
-        self.key_list    = rdm.split(self.master_key, num=n_components)
-        self.stream_no   = jnp.arange(0, n_components, dtype=jnp.int16)
-        self.stream_id   = [f"{seed}-{seq_no:{0}>3}" for seq_no in self.stream_no]
+        self.master_key  = rdm.PRNGKey(self.seed)
+        self.key_list    = rdm.split(self.master_key, num=self.n_components)
+        self.stream_no   = jnp.arange(0, self.n_components, dtype=jnp.int16)
+        self.stream_id   = [f"{self.seed}-{seq_no:{0}>3}" for seq_no in self.stream_no]
         self.registry    = [None for _ in self.stream_no]
 
         for key in predefined_components:

--- a/xgmutil/stream.py
+++ b/xgmutil/stream.py
@@ -8,9 +8,16 @@ class Stream:
     def __init__(self, **kwargs):
 
         self.force_no_gpu = kwargs.get('force_no_gpu',False)
-        self.seedkey      = kwargs.get('seedkey', rnd.PRNGKey(123456789))
+        self._seedkey     = kwargs.get('seedkey', rnd.PRNGKey(123456789))
+        if isinstance(self._seedkey, int):
+            self._seedkey = rnd.PRNGKey(self._seedkey)
+        self._PRNGkey      = self._seedkey
         self.nsub         = kwargs.get('nsub',1024**3)
         self.dtype        = kwargs.get('dtype', jnp.float32)
+
+    def set_seedkey(self, mc):
+        if isinstance(mc, int):
+            self._PRNGkey = rnd.fold_in(self._seedkey, mc)
 
     def generate(self,**kwargs):
 
@@ -21,13 +28,10 @@ class Stream:
         start = kwargs.get('start',0)
         size  = kwargs.get('size' ,1)
         dist  = kwargs.get('dist','normal')
-        mc    = kwargs.get('mc', 0)
 
         if self.dtype in [jnp.float64, jnp.complex128]:
             _JAX_X64_INITIAL_STATE = jax.config.read('jax_enable_x64')
             jax.config.update('jax_enable_x64', True)
-
-        key4mc = rnd.fold_in(self.seedkey, mc)
 
         end = start + size - 1
 
@@ -36,7 +40,7 @@ class Stream:
 
         seqIDs = jnp.arange(start_seqID, end_seqID+1)
 
-        keys = jax.vmap(rnd.fold_in, in_axes=(None, 0), out_axes=0)(key4mc, seqIDs)
+        keys = jax.vmap(rnd.fold_in, in_axes=(None, 0), out_axes=0)(self._PRNGkey, seqIDs)
 
         seq = jnp.zeros(0,dtype=jnp.float32)
 

--- a/xgmutil/stream.py
+++ b/xgmutil/stream.py
@@ -10,6 +10,7 @@ class Stream:
         self.force_no_gpu = kwargs.get('force_no_gpu',False)
         self.seedkey      = kwargs.get('seedkey', rnd.PRNGKey(123456789))
         self.nsub         = kwargs.get('nsub',1024**3)
+        self.dtype        = kwargs.get('dtype', jnp.float32)
 
     def generate(self,**kwargs):
 
@@ -20,10 +21,9 @@ class Stream:
         start = kwargs.get('start',0)
         size  = kwargs.get('size' ,1)
         dist  = kwargs.get('dist','normal')
-        dtype = kwargs.get('dtype', jnp.float32)
         mc    = kwargs.get('mc', 0)
 
-        if dtype in [jnp.float64, jnp.complex128, jnp.int64]:
+        if self.dtype in [jnp.float64, jnp.complex128]:
             _JAX_X64_INITIAL_STATE = jax.config.read('jax_enable_x64')
             jax.config.update('jax_enable_x64', True)
 
@@ -46,14 +46,14 @@ class Stream:
             subseq_end   = min((seqID+1) * self.nsub -1,end) - seqID * self.nsub
 
             if dist == 'normal':
-                subseq = rnd.normal(keys[seqID], dtype=dtype, shape=(self.nsub,))
+                subseq = rnd.normal(keys[seqID], dtype=self.dtype, shape=(self.nsub,))
 
             seq = jnp.concatenate((seq,subseq[subseq_start:subseq_end+1]))
         
         if self.force_no_gpu:
             jax.default_device(_JAX_PLATFORM_NAME)
 
-        if dtype in [jnp.float64, jnp.complex128, jnp.int64]:
+        if self.dtype in [jnp.float64, jnp.complex128, jnp.int64]:
             jax.config.update('jax_enable_x64', _JAX_X64_INITIAL_STATE)
 
         return seq

--- a/xgmutil/stream.py
+++ b/xgmutil/stream.py
@@ -1,7 +1,6 @@
 import jax.numpy as jnp 
 import jax.random as rnd
 import jax
-import sys
 import os
 
 class Stream:
@@ -9,18 +8,26 @@ class Stream:
     def __init__(self, **kwargs):
 
         self.force_no_gpu = kwargs.get('force_no_gpu',False)
-        self.seed         = kwargs.get('seed',123456789)
+        self.seedkey      = kwargs.get('seedkey', rnd.PRNGKey(123456789))
         self.nsub         = kwargs.get('nsub',1024**3)
 
     def generate(self,**kwargs):
 
         if self.force_no_gpu:
-            _JAX_PLATFORM_NAME = os.environ["JAX_PLATFORM_NAME"]
-            os.environ["JAX_PLATFORM_NAME"] = "cpu"
+            _JAX_PLATFORM_NAME = jax.default_backend()
+            jax.default_device("cpu")
 
         start = kwargs.get('start',0)
         size  = kwargs.get('size' ,1)
         dist  = kwargs.get('dist','normal')
+        dtype = kwargs.get('dtype', jnp.float32)
+        mc    = kwargs.get('mc', 0)
+
+        if dtype in [jnp.float64, jnp.complex128, jnp.int64]:
+            _JAX_X64_INITIAL_STATE = jax.config.read('jax_enable_x64')
+            jax.config.update('jax_enable_x64', True)
+
+        key4mc = rnd.fold_in(self.seedkey, mc)
 
         end = start + size - 1
 
@@ -29,9 +36,7 @@ class Stream:
 
         seqIDs = jnp.arange(start_seqID, end_seqID+1)
 
-        seedkey = rnd.PRNGKey(self.seed)
-
-        keys = jax.vmap(rnd.fold_in, in_axes=(None, 0), out_axes=0)(seedkey, seqIDs)
+        keys = jax.vmap(rnd.fold_in, in_axes=(None, 0), out_axes=0)(key4mc, seqIDs)
 
         seq = jnp.zeros(0,dtype=jnp.float32)
 
@@ -40,12 +45,16 @@ class Stream:
             subseq_start = max(seqID * self.nsub, start) - seqID * self.nsub
             subseq_end   = min((seqID+1) * self.nsub -1,end) - seqID * self.nsub
 
-            subseq = rnd.normal(keys[seqID], dtype=jnp.float32, shape=(self.nsub,))
+            if dist == 'normal':
+                subseq = rnd.normal(keys[seqID], dtype=dtype, shape=(self.nsub,))
 
             seq = jnp.concatenate((seq,subseq[subseq_start:subseq_end+1]))
         
         if self.force_no_gpu:
-            os.environ["JAX_PLATFORM_NAME"] = _JAX_PLATFORM_NAME
+            jax.default_device(_JAX_PLATFORM_NAME)
+
+        if dtype in [jnp.float64, jnp.complex128, jnp.int64]:
+            jax.config.update('jax_enable_x64', _JAX_X64_INITIAL_STATE)
 
         return seq
 


### PR DESCRIPTION
This PR adds new higher level random module for overall random stream management. As a part of this effort we checked complex and real random number reproducibility across different hardware. This detailed in issue https://github.com/exgalsky/xgmutil/issues/1 . Based on this, by deafult all random number is generated at 64bits.

1. The `random` module now manages the random number streams based on single initial seed with accessible metadata.
2. The `RNG_manager` class creates and manages all `RNG_component` classes for each individual stream.
3. The `stream` module still handles the scalable random number generation as before but `stream.Stream` does to take a seed directly instead using a `PRNGKey`, that is passed from `random` module.  The `stream.Stream` allows setting the jax numpy data type of the random number stream.
4. `Stream.generate` uses new kwarg `mc` to specify realization of the random stream. If the start and size remain same, `mc` allows deterministic generation of new random numbers.

Tested on CPU and GPU. 